### PR TITLE
feat: 사용자 관심 종목 작업, 여러 종목 등록

### DIFF
--- a/src/main/java/com/coin_notify/coin_notify/controller/LikeCoinController.java
+++ b/src/main/java/com/coin_notify/coin_notify/controller/LikeCoinController.java
@@ -1,0 +1,28 @@
+package com.coin_notify.coin_notify.controller;
+
+import com.coin_notify.coin_notify.response.ApiResponse;
+import com.coin_notify.coin_notify.service.LikeCoinService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api/coins")
+public class LikeCoinController {
+	private final LikeCoinService likeCoinService;
+
+	@Autowired
+	public LikeCoinController(LikeCoinService likeCoinService) {
+		this.likeCoinService = likeCoinService;
+	}
+
+	@PostMapping("/like/{coinId}")
+	public Mono<ResponseEntity<ApiResponse<String>>> addLikeCoin(@PathVariable(name = "coinId", required = true) Long coinId, HttpServletRequest request) {
+		return likeCoinService.addLikeCoin(request, coinId);
+	}
+}

--- a/src/main/java/com/coin_notify/coin_notify/controller/MarketController.java
+++ b/src/main/java/com/coin_notify/coin_notify/controller/MarketController.java
@@ -1,23 +1,35 @@
 package com.coin_notify.coin_notify.controller;
 
+import com.coin_notify.coin_notify.response.ApiResponse;
+import com.coin_notify.coin_notify.service.LikeMarketService;
 import com.coin_notify.coin_notify.service.MarketService;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
 @RestController
 public class MarketController {
 	private final MarketService marketService;
+	private final LikeMarketService likeMarketService;
 
 	@Autowired
-	public MarketController(MarketService marketService) {
+	public MarketController(MarketService marketService, LikeMarketService likeMarketService) {
 		this.marketService = marketService;
+		this.likeMarketService = likeMarketService;
 	}
 
 	@GetMapping("/market-collect")
 	public Mono<ResponseEntity<String>> process() {
 		return marketService.marketCollectionProcess().thenReturn(ResponseEntity.ok("ok"));
+	}
+
+	@PostMapping("/api/markets/like/{marketId}")
+	public Mono<ResponseEntity<ApiResponse<String>>> addLikeMarket(@PathVariable(name = "marketId", required = true) Long marketId, HttpServletRequest request) {
+		return likeMarketService.addLikeMarket(request, marketId);
 	}
 }

--- a/src/main/java/com/coin_notify/coin_notify/controller/UserController.java
+++ b/src/main/java/com/coin_notify/coin_notify/controller/UserController.java
@@ -1,0 +1,27 @@
+package com.coin_notify.coin_notify.controller;
+
+import com.coin_notify.coin_notify.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+@RestController
+public class UserController {
+	private final UserService userService;
+
+	@Autowired
+	public UserController(UserService userService) {
+		this.userService = userService;
+	}
+
+	@GetMapping("/")
+	public Mono<ResponseEntity<UUID>> setupUserSession(HttpServletRequest request) {
+		return userService.setupUserSession(request)
+				.map(ResponseEntity::ok);
+	}
+}

--- a/src/main/java/com/coin_notify/coin_notify/data/entity/LikeCoinEntity.java
+++ b/src/main/java/com/coin_notify/coin_notify/data/entity/LikeCoinEntity.java
@@ -18,4 +18,7 @@ public class LikeCoinEntity extends BasicEntity {
 
 	@Column("coin_id")
 	private Long coinId;
+
+	@Column("is_active")
+	private Boolean isActive;
 }

--- a/src/main/java/com/coin_notify/coin_notify/data/entity/LikeCoinEntity.java
+++ b/src/main/java/com/coin_notify/coin_notify/data/entity/LikeCoinEntity.java
@@ -1,0 +1,21 @@
+package com.coin_notify.coin_notify.data.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Getter
+@Setter
+@Table("like_coins")
+public class LikeCoinEntity extends BasicEntity {
+	@Id
+	private Long id;
+
+	@Column("user_id")
+	private Long userId;
+
+	@Column("coin_id")
+	private Long coinId;
+}

--- a/src/main/java/com/coin_notify/coin_notify/data/entity/LikeMarketEntity.java
+++ b/src/main/java/com/coin_notify/coin_notify/data/entity/LikeMarketEntity.java
@@ -1,0 +1,21 @@
+package com.coin_notify.coin_notify.data.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Getter
+@Setter
+@Table("like_markets")
+public class LikeMarketEntity extends BasicEntity {
+	@Id
+	private Long id;
+
+	@Column("user_id")
+	private Long userId;
+
+	@Column("market_id")
+	private Long marketId;
+}

--- a/src/main/java/com/coin_notify/coin_notify/data/entity/LikeMarketEntity.java
+++ b/src/main/java/com/coin_notify/coin_notify/data/entity/LikeMarketEntity.java
@@ -18,4 +18,7 @@ public class LikeMarketEntity extends BasicEntity {
 
 	@Column("market_id")
 	private Long marketId;
+
+	@Column("is_active")
+	private Boolean isActive;
 }

--- a/src/main/java/com/coin_notify/coin_notify/data/entity/UserEntity.java
+++ b/src/main/java/com/coin_notify/coin_notify/data/entity/UserEntity.java
@@ -1,0 +1,23 @@
+package com.coin_notify.coin_notify.data.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@Table("users")
+public class UserEntity extends BasicEntity {
+	@Id
+	private Long id;
+
+	@Column("uuid")
+	private UUID uuid;
+
+	@Column("user_agent")
+	private String userAgent;
+}

--- a/src/main/java/com/coin_notify/coin_notify/data/repository/LikeCoinRepository.java
+++ b/src/main/java/com/coin_notify/coin_notify/data/repository/LikeCoinRepository.java
@@ -1,0 +1,9 @@
+package com.coin_notify.coin_notify.data.repository;
+
+import com.coin_notify.coin_notify.data.entity.LikeCoinEntity;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Mono;
+
+public interface LikeCoinRepository extends ReactiveCrudRepository<LikeCoinEntity, Long> {
+	Mono<LikeCoinEntity> findByUserIdAndCoinId(Long userId, Long coinId);
+}

--- a/src/main/java/com/coin_notify/coin_notify/data/repository/LikeMarketRepository.java
+++ b/src/main/java/com/coin_notify/coin_notify/data/repository/LikeMarketRepository.java
@@ -1,0 +1,9 @@
+package com.coin_notify.coin_notify.data.repository;
+
+import com.coin_notify.coin_notify.data.entity.LikeMarketEntity;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Mono;
+
+public interface LikeMarketRepository extends ReactiveCrudRepository<LikeMarketEntity, Long> {
+	Mono<LikeMarketEntity> findByUserIdAndMarketId(Long userId, Long marketId);
+}

--- a/src/main/java/com/coin_notify/coin_notify/data/repository/UserRepository.java
+++ b/src/main/java/com/coin_notify/coin_notify/data/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.coin_notify.coin_notify.data.repository;
+
+import com.coin_notify.coin_notify.data.entity.UserEntity;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+public interface UserRepository extends ReactiveCrudRepository<UserEntity, Long> {
+}

--- a/src/main/java/com/coin_notify/coin_notify/data/repository/UserRepository.java
+++ b/src/main/java/com/coin_notify/coin_notify/data/repository/UserRepository.java
@@ -2,6 +2,10 @@ package com.coin_notify.coin_notify.data.repository;
 
 import com.coin_notify.coin_notify.data.entity.UserEntity;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
 
 public interface UserRepository extends ReactiveCrudRepository<UserEntity, Long> {
+	Mono<UserEntity> findByUuid(UUID uuid);
 }

--- a/src/main/java/com/coin_notify/coin_notify/exception/CustomException.java
+++ b/src/main/java/com/coin_notify/coin_notify/exception/CustomException.java
@@ -1,0 +1,5 @@
+package com.coin_notify.coin_notify.exception;
+
+public record CustomException(int httpStatusCode, int serviceExceptionCode, String message) {
+
+}

--- a/src/main/java/com/coin_notify/coin_notify/response/ApiResponse.java
+++ b/src/main/java/com/coin_notify/coin_notify/response/ApiResponse.java
@@ -1,0 +1,18 @@
+package com.coin_notify.coin_notify.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ApiResponse<T> {
+	private String resultCode;
+	private String resultMessage;
+	private T resultData;
+
+	public ApiResponse(String resultCode, String resultMessage, T resultData) {
+		this.resultCode = resultCode;
+		this.resultMessage = resultMessage;
+		this.resultData = resultData;
+	}
+}

--- a/src/main/java/com/coin_notify/coin_notify/response/ErrorMessage.java
+++ b/src/main/java/com/coin_notify/coin_notify/response/ErrorMessage.java
@@ -8,7 +8,6 @@ import org.springframework.http.ResponseEntity;
 @Getter
 public enum ErrorMessage {
 	USER_UUID_NOT_FOUND(new CustomException(HttpStatus.BAD_REQUEST.value(), 990101, "세션에서 사용자 UUID를 찾을 수 없습니다.")),
-	ALREADY_LIKED(new CustomException(HttpStatus.BAD_REQUEST.value(), 990102, "이미 좋아요를 누른 데이터입니다.")),
 	USER_NOT_FOUND(new CustomException(HttpStatus.BAD_REQUEST.value(), 990103, "회원을 찾을 수 없습니다."));
 
 	private final CustomException exception;

--- a/src/main/java/com/coin_notify/coin_notify/response/ErrorMessage.java
+++ b/src/main/java/com/coin_notify/coin_notify/response/ErrorMessage.java
@@ -1,0 +1,28 @@
+package com.coin_notify.coin_notify.response;
+
+import com.coin_notify.coin_notify.exception.CustomException;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+public enum ErrorMessage {
+	USER_UUID_NOT_FOUND(new CustomException(HttpStatus.BAD_REQUEST.value(), 990101, "세션에서 사용자 UUID를 찾을 수 없습니다.")),
+	ALREADY_LIKED(new CustomException(HttpStatus.BAD_REQUEST.value(), 990102, "이미 좋아요를 누른 데이터입니다.")),
+	USER_NOT_FOUND(new CustomException(HttpStatus.BAD_REQUEST.value(), 990103, "회원을 찾을 수 없습니다."));
+
+	private final CustomException exception;
+
+	ErrorMessage(CustomException exception) {
+		this.exception = exception;
+	}
+
+	public ResponseEntity<ApiResponse<String>> toResponseEntity() {
+		ApiResponse<String> response = new ApiResponse<>(
+				exception.serviceExceptionCode() + "",
+				exception.httpStatusCode() == HttpStatus.OK.value() ? "Success" : "Bad Request",
+				exception.message()
+		);
+		return ResponseEntity.status(HttpStatus.valueOf(exception.httpStatusCode())).body(response);
+	}
+}

--- a/src/main/java/com/coin_notify/coin_notify/service/LikeCoinService.java
+++ b/src/main/java/com/coin_notify/coin_notify/service/LikeCoinService.java
@@ -1,0 +1,50 @@
+package com.coin_notify.coin_notify.service;
+
+import com.coin_notify.coin_notify.data.entity.LikeCoinEntity;
+import com.coin_notify.coin_notify.data.repository.LikeCoinRepository;
+import com.coin_notify.coin_notify.data.repository.UserRepository;
+import com.coin_notify.coin_notify.response.ApiResponse;
+import com.coin_notify.coin_notify.response.ErrorMessage;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+@Service
+public class LikeCoinService {
+	private final LikeCoinRepository likeCoinRepository;
+	private final UserRepository userRepository;
+
+	public LikeCoinService(LikeCoinRepository likeCoinRepository, UserRepository userRepository) {
+		this.likeCoinRepository = likeCoinRepository;
+		this.userRepository = userRepository;
+	}
+
+	public Mono<ResponseEntity<ApiResponse<String>>> addLikeCoin(HttpServletRequest request, Long coinId) {
+		UUID userUuid = (UUID) request.getSession().getAttribute("user_uuid");
+		if (userUuid == null) {
+			return Mono.just(ErrorMessage.USER_UUID_NOT_FOUND.toResponseEntity());
+		}
+
+		return userRepository.findByUuid(userUuid).flatMap(user -> {
+			Long userId = user.getId();
+			return likeCoinRepository.findByUserIdAndCoinId(userId, coinId).flatMap(
+					existingLike -> Mono.just(ErrorMessage.ALREADY_LIKED.toResponseEntity())
+			).switchIfEmpty(Mono.defer(() -> {
+				LikeCoinEntity likeCoinEntity = new LikeCoinEntity();
+				likeCoinEntity.setUserId(userId);
+				likeCoinEntity.setCoinId(coinId);
+
+				return likeCoinRepository.save(likeCoinEntity).flatMap(savedEntity -> {
+					ApiResponse<String> response = new ApiResponse<>("A200", "Success", "ok");
+					return Mono.just(ResponseEntity.status(HttpStatus.OK).body(response));
+				}).doOnError(throwable -> {
+					System.out.println("오류 " + throwable.getMessage());
+				});
+			}));
+		}).switchIfEmpty(Mono.just(ErrorMessage.USER_NOT_FOUND.toResponseEntity()));
+	}
+}

--- a/src/main/java/com/coin_notify/coin_notify/service/LikeCoinService.java
+++ b/src/main/java/com/coin_notify/coin_notify/service/LikeCoinService.java
@@ -15,36 +15,46 @@ import java.util.UUID;
 
 @Service
 public class LikeCoinService {
-	private final LikeCoinRepository likeCoinRepository;
-	private final UserRepository userRepository;
+    private final LikeCoinRepository likeCoinRepository;
+    private final UserRepository userRepository;
 
-	public LikeCoinService(LikeCoinRepository likeCoinRepository, UserRepository userRepository) {
-		this.likeCoinRepository = likeCoinRepository;
-		this.userRepository = userRepository;
-	}
+    public LikeCoinService(LikeCoinRepository likeCoinRepository, UserRepository userRepository) {
+        this.likeCoinRepository = likeCoinRepository;
+        this.userRepository = userRepository;
+    }
 
-	public Mono<ResponseEntity<ApiResponse<String>>> addLikeCoin(HttpServletRequest request, Long coinId) {
-		UUID userUuid = (UUID) request.getSession().getAttribute("user_uuid");
-		if (userUuid == null) {
-			return Mono.just(ErrorMessage.USER_UUID_NOT_FOUND.toResponseEntity());
-		}
+    public Mono<ResponseEntity<ApiResponse<String>>> addLikeCoin(HttpServletRequest request, Long coinId) {
+        UUID userUuid = (UUID) request.getSession().getAttribute("user_uuid");
+        if (userUuid == null) {
+            return Mono.just(ErrorMessage.USER_UUID_NOT_FOUND.toResponseEntity());
+        }
 
-		return userRepository.findByUuid(userUuid).flatMap(user -> {
-			Long userId = user.getId();
-			return likeCoinRepository.findByUserIdAndCoinId(userId, coinId).flatMap(
-					existingLike -> Mono.just(ErrorMessage.ALREADY_LIKED.toResponseEntity())
-			).switchIfEmpty(Mono.defer(() -> {
-				LikeCoinEntity likeCoinEntity = new LikeCoinEntity();
-				likeCoinEntity.setUserId(userId);
-				likeCoinEntity.setCoinId(coinId);
+        return userRepository.findByUuid(userUuid).flatMap(user -> {
+            Long userId = user.getId();
 
-				return likeCoinRepository.save(likeCoinEntity).flatMap(savedEntity -> {
-					ApiResponse<String> response = new ApiResponse<>("A200", "Success", "ok");
-					return Mono.just(ResponseEntity.status(HttpStatus.OK).body(response));
-				}).doOnError(throwable -> {
-					System.out.println("오류 " + throwable.getMessage());
-				});
-			}));
-		}).switchIfEmpty(Mono.just(ErrorMessage.USER_NOT_FOUND.toResponseEntity()));
-	}
+            return likeCoinRepository.findByUserIdAndCoinId(userId, coinId).flatMap(
+                    existingLike -> {
+                        existingLike.setIsActive(false);
+                        return likeCoinRepository.save(existingLike).flatMap(savedEntity -> {
+                            ApiResponse<String> response = new ApiResponse<>("A200", "Like Removed",
+                                    "false");
+                            return Mono.just((ResponseEntity.status(HttpStatus.OK).body(response)));
+                        }).doOnError(throwable -> {
+                            System.out.println("오류 " + throwable.getMessage());
+                        });
+                    }).switchIfEmpty(Mono.defer(() -> {
+                LikeCoinEntity likeCoinEntity = new LikeCoinEntity();
+                likeCoinEntity.setUserId(userId);
+                likeCoinEntity.setCoinId(coinId);
+                likeCoinEntity.setIsActive(true);
+
+                return likeCoinRepository.save(likeCoinEntity).flatMap(savedEntity -> {
+                    ApiResponse<String> response = new ApiResponse<>("A200", "Success", "true");
+                    return Mono.just(ResponseEntity.status(HttpStatus.OK).body(response));
+                }).doOnError(throwable -> {
+                    System.out.println("오류 " + throwable.getMessage());
+                });
+            }));
+        }).switchIfEmpty(Mono.just(ErrorMessage.USER_NOT_FOUND.toResponseEntity()));
+    }
 }

--- a/src/main/java/com/coin_notify/coin_notify/service/LikeMarketService.java
+++ b/src/main/java/com/coin_notify/coin_notify/service/LikeMarketService.java
@@ -15,36 +15,49 @@ import java.util.UUID;
 
 @Service
 public class LikeMarketService {
-	private final LikeMarketRepository likeMarketRepository;
-	private final UserRepository userRepository;
+    private final LikeMarketRepository likeMarketRepository;
+    private final UserRepository userRepository;
 
-	public LikeMarketService(LikeMarketRepository likeMarketRepository, UserRepository userRepository) {
-		this.likeMarketRepository = likeMarketRepository;
-		this.userRepository = userRepository;
-	}
+    public LikeMarketService(LikeMarketRepository likeMarketRepository, UserRepository userRepository) {
+        this.likeMarketRepository = likeMarketRepository;
+        this.userRepository = userRepository;
+    }
 
-	public Mono<ResponseEntity<ApiResponse<String>>> addLikeMarket(HttpServletRequest request, Long marketId) {
-		UUID userUuid = (UUID) request.getSession().getAttribute("user_uuid");
-		if (userUuid == null) {
-			return Mono.just(ErrorMessage.USER_UUID_NOT_FOUND.toResponseEntity());
-		}
+    public Mono<ResponseEntity<ApiResponse<String>>> addLikeMarket(HttpServletRequest request, Long marketId) {
+        UUID userUuid = (UUID) request.getSession().getAttribute("user_uuid");
+        if (userUuid == null) {
+            return Mono.just(ErrorMessage.USER_UUID_NOT_FOUND.toResponseEntity());
+        }
 
-		return userRepository.findByUuid(userUuid).flatMap(user -> {
-			Long userId = user.getId();
-			return likeMarketRepository.findByUserIdAndMarketId(userId, marketId).flatMap(
-					existingLike -> Mono.just(ErrorMessage.ALREADY_LIKED.toResponseEntity())
-			).switchIfEmpty(Mono.defer(() -> {
-				LikeMarketEntity likeMarketEntity = new LikeMarketEntity();
-				likeMarketEntity.setUserId(userId);
-				likeMarketEntity.setMarketId(marketId);
+        return userRepository.findByUuid(userUuid).flatMap(user -> {
+            Long userId = user.getId();
 
-				return likeMarketRepository.save(likeMarketEntity).flatMap(savedEntity -> {
-					ApiResponse<String> response = new ApiResponse<>("A200", "Success", "ok");
-					return Mono.just(ResponseEntity.status(HttpStatus.OK).body(response));
-				}).doOnError(throwable -> {
-					System.out.println("오류 " + throwable.getMessage());
-				});
-			}));
-		}).switchIfEmpty(Mono.just(ErrorMessage.USER_NOT_FOUND.toResponseEntity()));
-	}
+            return likeMarketRepository.findByUserIdAndMarketId(userId, marketId)
+                    .flatMap(existingLike -> {
+                        boolean newState = !Boolean.TRUE.equals(
+                                existingLike.getIsActive());
+                        existingLike.setIsActive(newState);
+
+                        String message = newState ? "Like Added" : "Like Removed";
+                        String data = Boolean.toString(newState);
+
+                        return likeMarketRepository.save(existingLike).flatMap(savedEntity -> {
+                            ApiResponse<String> response = new ApiResponse<>("A200", message, data);
+                            return Mono.just(ResponseEntity.status(HttpStatus.OK).body(response));
+                        });
+                    })
+                    .switchIfEmpty(Mono.defer(() -> {
+                        LikeMarketEntity likeMarketEntity = new LikeMarketEntity();
+                        likeMarketEntity.setUserId(userId);
+                        likeMarketEntity.setMarketId(marketId);
+                        likeMarketEntity.setIsActive(true);
+
+                        return likeMarketRepository.save(likeMarketEntity).flatMap(savedEntity -> {
+                            ApiResponse<String> response = new ApiResponse<>("A200", "Like Added",
+                                    "true");
+                            return Mono.just(ResponseEntity.status(HttpStatus.OK).body(response));
+                        });
+                    }));
+        }).switchIfEmpty(Mono.just(ErrorMessage.USER_NOT_FOUND.toResponseEntity()));
+    }
 }

--- a/src/main/java/com/coin_notify/coin_notify/service/LikeMarketService.java
+++ b/src/main/java/com/coin_notify/coin_notify/service/LikeMarketService.java
@@ -1,0 +1,50 @@
+package com.coin_notify.coin_notify.service;
+
+import com.coin_notify.coin_notify.data.entity.LikeMarketEntity;
+import com.coin_notify.coin_notify.data.repository.LikeMarketRepository;
+import com.coin_notify.coin_notify.data.repository.UserRepository;
+import com.coin_notify.coin_notify.response.ApiResponse;
+import com.coin_notify.coin_notify.response.ErrorMessage;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+@Service
+public class LikeMarketService {
+	private final LikeMarketRepository likeMarketRepository;
+	private final UserRepository userRepository;
+
+	public LikeMarketService(LikeMarketRepository likeMarketRepository, UserRepository userRepository) {
+		this.likeMarketRepository = likeMarketRepository;
+		this.userRepository = userRepository;
+	}
+
+	public Mono<ResponseEntity<ApiResponse<String>>> addLikeMarket(HttpServletRequest request, Long marketId) {
+		UUID userUuid = (UUID) request.getSession().getAttribute("user_uuid");
+		if (userUuid == null) {
+			return Mono.just(ErrorMessage.USER_UUID_NOT_FOUND.toResponseEntity());
+		}
+
+		return userRepository.findByUuid(userUuid).flatMap(user -> {
+			Long userId = user.getId();
+			return likeMarketRepository.findByUserIdAndMarketId(userId, marketId).flatMap(
+					existingLike -> Mono.just(ErrorMessage.ALREADY_LIKED.toResponseEntity())
+			).switchIfEmpty(Mono.defer(() -> {
+				LikeMarketEntity likeMarketEntity = new LikeMarketEntity();
+				likeMarketEntity.setUserId(userId);
+				likeMarketEntity.setMarketId(marketId);
+
+				return likeMarketRepository.save(likeMarketEntity).flatMap(savedEntity -> {
+					ApiResponse<String> response = new ApiResponse<>("A200", "Success", "ok");
+					return Mono.just(ResponseEntity.status(HttpStatus.OK).body(response));
+				}).doOnError(throwable -> {
+					System.out.println("오류 " + throwable.getMessage());
+				});
+			}));
+		}).switchIfEmpty(Mono.just(ErrorMessage.USER_NOT_FOUND.toResponseEntity()));
+	}
+}

--- a/src/main/java/com/coin_notify/coin_notify/service/MarketService.java
+++ b/src/main/java/com/coin_notify/coin_notify/service/MarketService.java
@@ -49,12 +49,10 @@ public class MarketService {
 
 	private Mono<Void> saveMarketData(JsonNode marketData) {
 		return Flux.fromIterable(marketData).map(data -> {
-			System.out.println(data);
 			MarketEntity marketEntity = new MarketEntity();
 			marketEntity.setMarketCode(data.get("market").asText());
 			marketEntity.setKoreanName(data.get("korean_name").asText());
 			marketEntity.setEnglishName(data.get("english_name").asText());
-			System.out.println(data.get("market_event"));
 			return marketEntity;
 		}).flatMap(marketRepository::save).doOnNext(saved -> System.out.println("Saved: " + saved.getMarketCode())).doOnError(error -> System.err.println("Error saving: " + error.getMessage())).then();
 	}

--- a/src/main/java/com/coin_notify/coin_notify/service/UserService.java
+++ b/src/main/java/com/coin_notify/coin_notify/service/UserService.java
@@ -1,0 +1,38 @@
+package com.coin_notify.coin_notify.service;
+
+import com.coin_notify.coin_notify.data.entity.UserEntity;
+import com.coin_notify.coin_notify.data.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+@Service
+public class UserService {
+	private final UserRepository userRepository;
+
+	public UserService(UserRepository userRepository) {
+		this.userRepository = userRepository;
+	}
+
+	public Mono<UUID> setupUserSession(HttpServletRequest request) {
+		UUID userUuid = (UUID)request.getSession().getAttribute("user_uuid");
+		String userAgent = request.getHeader("User-Agent");
+
+		if (userUuid == null) {
+			userUuid = UUID.randomUUID();
+			request.getSession().setAttribute("user_uuid", userUuid);
+			saveUser(userUuid, userAgent).block();
+		}
+
+		return Mono.just(userUuid);
+	}
+
+	private Mono<UserEntity> saveUser(UUID uuid, String userAgent) {
+		UserEntity userEntity = new UserEntity();
+		userEntity.setUuid(uuid);
+		userEntity.setUserAgent(userAgent);
+		return userRepository.save(userEntity);
+	}
+}

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -64,29 +64,31 @@ CREATE TABLE IF NOT EXISTS users
 CREATE TABLE IF NOT EXISTS like_coins
 (
     id         SERIAL PRIMARY KEY,
-    user_id    BIGINT NOT NULL,                     -- 사용자 ID
-    coin_id    BIGINT NOT NULL,                     -- 코인 심볼
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, -- 생성 일시
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, -- 수정 일시
-    deleted_at TIMESTAMP DEFAULT NULL,              -- 삭제 일시
-    UNIQUE (user_id, coin_id),                      -- 중복 저장 방지
+    user_id    BIGINT  NOT NULL,                           -- 사용자 ID
+    coin_id    BIGINT  NOT NULL,                           -- 코인 심볼
+    is_active  BOOLEAN NOT NULL DEFAULT FALSE,             -- 좋아요 활성화
+    created_at TIMESTAMP        DEFAULT CURRENT_TIMESTAMP, -- 생성 일시
+    updated_at TIMESTAMP        DEFAULT CURRENT_TIMESTAMP, -- 수정 일시
+    deleted_at TIMESTAMP        DEFAULT NULL,              -- 삭제 일시
+    UNIQUE (user_id, coin_id),                             -- 중복 저장 방지
     CONSTRAINT fk_user FOREIGN KEY (user_id)
-        REFERENCES users (id) ON DELETE CASCADE,    -- users 테이블에 FK 연결
+        REFERENCES users (id) ON DELETE CASCADE,           -- users 테이블에 FK 연결
     CONSTRAINT fk_coin FOREIGN KEY (coin_id)
-        REFERENCES coins (id) ON DELETE CASCADE     -- coins 테이블에 FK 연결
+        REFERENCES coins (id) ON DELETE CASCADE            -- coins 테이블에 FK 연결
 );
 
 CREATE TABLE IF NOT EXISTS like_markets
 (
     id         SERIAL PRIMARY KEY,
-    user_id    BIGINT NOT NULL,                     -- 사용자 ID
-    market_id  BIGINT NOT NULL,                     -- 마켓 이름 (예: 'KRW-BTC' 등)
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, -- 생성 일시
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, -- 수정 일시
-    deleted_at TIMESTAMP DEFAULT NULL,              -- 삭제 일시
-    UNIQUE (user_id, market_id),                    -- 중복 저장 방지
+    user_id    BIGINT  NOT NULL,                           -- 사용자 ID
+    market_id  BIGINT  NOT NULL,                           -- 마켓 이름 (예: 'KRW-BTC' 등)
+    is_active  BOOLEAN NOT NULL DEFAULT FALSE,             -- 좋아요 활성화
+    created_at TIMESTAMP        DEFAULT CURRENT_TIMESTAMP, -- 생성 일시
+    updated_at TIMESTAMP        DEFAULT CURRENT_TIMESTAMP, -- 수정 일시
+    deleted_at TIMESTAMP        DEFAULT NULL,              -- 삭제 일시
+    UNIQUE (user_id, market_id),                           -- 중복 저장 방지
     CONSTRAINT fk_user FOREIGN KEY (user_id)
-        REFERENCES users (id) ON DELETE CASCADE,    -- users 테이블에 FK 연결
+        REFERENCES users (id) ON DELETE CASCADE,           -- users 테이블에 FK 연결
     CONSTRAINT fk_market FOREIGN KEY (market_id)
-        REFERENCES markets (id) ON DELETE CASCADE   -- markets 테이블에 FK 연결
+        REFERENCES markets (id) ON DELETE CASCADE          -- markets 테이블에 FK 연결
 );

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -49,3 +49,44 @@ CREATE TABLE IF NOT EXISTS real_time_prices
     CONSTRAINT fk_market FOREIGN KEY (market_id)
         REFERENCES markets (id)                               -- 외래키 제약조건
 );
+
+CREATE TABLE IF NOT EXISTS users
+(
+    id         BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY, -- 사용자 ID, 자동 증가
+    uuid       UUID NOT NULL,                                   -- UUID, 고유 식별자
+    user_agent varchar(255),                                    -- 사용자 에이전트 (User-Agent), 사용자의 브라우저 및 장치 정보
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,           -- 생성 일시
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,           -- 수정 일시
+    deleted_at TIMESTAMPTZ DEFAULT NULL,                        -- 삭제 일시
+    CONSTRAINT unique_uuid UNIQUE (uuid)                        -- UUID
+);
+
+CREATE TABLE IF NOT EXISTS like_coins
+(
+    id         SERIAL PRIMARY KEY,
+    user_id    BIGINT NOT NULL,                     -- 사용자 ID
+    coin_id    BIGINT NOT NULL,                     -- 코인 심볼
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, -- 생성 일시
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, -- 수정 일시
+    deleted_at TIMESTAMP DEFAULT NULL,              -- 삭제 일시
+    UNIQUE (user_id, coin_id),                      -- 중복 저장 방지
+    CONSTRAINT fk_user FOREIGN KEY (user_id)
+        REFERENCES users (id) ON DELETE CASCADE,    -- users 테이블에 FK 연결
+    CONSTRAINT fk_coin FOREIGN KEY (coin_id)
+        REFERENCES coins (id) ON DELETE CASCADE     -- coins 테이블에 FK 연결
+);
+
+CREATE TABLE IF NOT EXISTS like_markets
+(
+    id         SERIAL PRIMARY KEY,
+    user_id    BIGINT NOT NULL,                     -- 사용자 ID
+    market_id  BIGINT NOT NULL,                     -- 마켓 이름 (예: 'KRW-BTC' 등)
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, -- 생성 일시
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, -- 수정 일시
+    deleted_at TIMESTAMP DEFAULT NULL,              -- 삭제 일시
+    UNIQUE (user_id, market_id),                    -- 중복 저장 방지
+    CONSTRAINT fk_user FOREIGN KEY (user_id)
+        REFERENCES users (id) ON DELETE CASCADE,    -- users 테이블에 FK 연결
+    CONSTRAINT fk_market FOREIGN KEY (market_id)
+        REFERENCES markets (id) ON DELETE CASCADE   -- markets 테이블에 FK 연결
+);


### PR DESCRIPTION
feat: 사용자 관심 종목 작업, 여러 종목 등록
`coin-notify` 병합 브랜치

- 사용자 uuid 초기화 및 세션 관리
- 코인, 종목 관심 종목 등록 (`like_coins`, 'like_markets` 테이블 추가)